### PR TITLE
added get and count method in both storage engines

### DIFF
--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -91,12 +91,5 @@ class DBStorage:
         If no class is passed, returns the count of all objects in storage.
         """
         if cls:
-            count = 0
-            for obj in self.all(cls).values():
-                count += 1
-            return count
-        else:
-            count_all = 0
-            for obj in self.all().values():
-                count_all += 1
-            return count_all
+            return len(self.all(cls).values())
+        return len(self.all().values())

--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -76,8 +76,10 @@ class DBStorage:
         self.__session.remove()
 
     def get(self, cls, id):
-        """Returns the object based on the class and its ID,
-        or None if not found"""
+        """
+        Returns the object based on the class and its ID,
+        or None if not found
+        """
         for obj in self.all(cls).values():
             if obj.id == id:
                 return obj

--- a/models/engine/db_storage.py
+++ b/models/engine/db_storage.py
@@ -74,3 +74,27 @@ class DBStorage:
     def close(self):
         """call remove() method on the private session attribute"""
         self.__session.remove()
+
+    def get(self, cls, id):
+        """Returns the object based on the class and its ID,
+        or None if not found"""
+        for obj in self.all(cls).values():
+            if obj.id == id:
+                return obj
+            return None
+
+    def count(self, cls=None):
+        """
+        Returns the number of objects in storage matching the given class.
+        If no class is passed, returns the count of all objects in storage.
+        """
+        if cls:
+            count = 0
+            for obj in self.all(cls).values():
+                count += 1
+            return count
+        else:
+            count_all = 0
+            for obj in self.all().values():
+                count_all += 1
+            return count_all

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -84,12 +84,14 @@ class FileStorage:
         If no class is passed, returns the count of all objects in storage.
         """
         if cls:
-            count = 0
-            for obj in self.all(cls).values():
-                count += 1
-            return count
-        else:
-            count_all = 0
-            for obj in self.__objects.values():
-                count_all += 1
-            return count_all
+            return len(self.all(cls).values())
+        return len(self.all().values())
+    def count(self, cls=None):
+        """
+        Returns the number of objects in storage matching the given class.
+        If no class is passed, returns the count of all objects in storage.
+        """
+        if cls:
+            return len(self.all(cls).values())
+        return len(self.all().values())
+

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -55,7 +55,7 @@ class FileStorage:
                 jo = json.load(f)
             for key in jo:
                 self.__objects[key] = classes[jo[key]["__class__"]](**jo[key])
-        except FileNotFoundError:
+        except:
             pass
 
     def delete(self, obj=None):

--- a/models/engine/file_storage.py
+++ b/models/engine/file_storage.py
@@ -55,7 +55,7 @@ class FileStorage:
                 jo = json.load(f)
             for key in jo:
                 self.__objects[key] = classes[jo[key]["__class__"]](**jo[key])
-        except:
+        except FileNotFoundError:
             pass
 
     def delete(self, obj=None):
@@ -68,3 +68,28 @@ class FileStorage:
     def close(self):
         """call reload() method for deserializing the JSON file to objects"""
         self.reload()
+
+    def get(self, cls, id):
+        """
+        Returns the object based on the class and its ID,
+        or None if not found"""
+        for obj in self.all(cls).values():
+            if obj.id == id:
+                return obj
+            return None
+
+    def count(self, cls=None):
+        """
+        Returns the number of objects in storage matching the given class.
+        If no class is passed, returns the count of all objects in storage.
+        """
+        if cls:
+            count = 0
+            for obj in self.all(cls).values():
+                count += 1
+            return count
+        else:
+            count_all = 0
+            for obj in self.__objects.values():
+                count_all += 1
+            return count_all

--- a/tests/test_models/test_engine/test_db_storage.py
+++ b/tests/test_models/test_engine/test_db_storage.py
@@ -6,6 +6,7 @@ Contains the TestDBStorageDocs and TestDBStorage classes
 from datetime import datetime
 import inspect
 import models
+from models import storage
 from models.engine import db_storage
 from models.amenity import Amenity
 from models.base_model import BaseModel
@@ -18,6 +19,8 @@ import json
 import os
 import pep8
 import unittest
+
+
 DBStorage = db_storage.DBStorage
 classes = {"Amenity": Amenity, "City": City, "Place": Place,
            "Review": Review, "State": State, "User": User}
@@ -86,3 +89,19 @@ class TestFileStorage(unittest.TestCase):
     @unittest.skipIf(models.storage_t != 'db', "not testing db storage")
     def test_save(self):
         """Test that save properly saves objects to file.json"""
+
+    def test_get_obj_found(self):
+        """test getting the obj by it's class and id
+        when the obj is present"""
+        first_state_id = list(storage.all(User).values())[0].id
+        obj = storage.get(User, first_state_id)
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.id, first_state_id)
+
+    def test_get_obj_notfound(self):
+        """test getting the obj by it's class and id
+        when the obj is not present"""
+        obj = storage.get(User, "1234")
+        self.assertEqual(obj, None)
+
+

--- a/tests/test_models/test_engine/test_file_storage.py
+++ b/tests/test_models/test_engine/test_file_storage.py
@@ -6,6 +6,7 @@ Contains the TestFileStorageDocs classes
 from datetime import datetime
 import inspect
 import models
+from models import storage
 from models.engine import file_storage
 from models.amenity import Amenity
 from models.base_model import BaseModel
@@ -18,6 +19,7 @@ import json
 import os
 import pep8
 import unittest
+
 FileStorage = file_storage.FileStorage
 classes = {"Amenity": Amenity, "BaseModel": BaseModel, "City": City,
            "Place": Place, "Review": Review, "State": State, "User": User}
@@ -113,3 +115,17 @@ class TestFileStorage(unittest.TestCase):
         with open("file.json", "r") as f:
             js = f.read()
         self.assertEqual(json.loads(string), json.loads(js))
+
+    def test_get_obj_found(self):
+        """test getting the obj by it's class and id
+        when the obj is present"""
+        first_state_id = list(storage.all(User).values())[0].id
+        obj = storage.get(User, first_state_id)
+        self.assertIsNotNone(obj)
+        self.assertEqual(obj.id, first_state_id)
+
+    def test_get_obj_notfound(self):
+        """test getting the obj by it's class and id
+        when the obj is not present"""
+        obj = storage.get(User, "1234")
+        self.assertEqual(obj, None)

--- a/tests/test_models/test_engine/test_get_count.py
+++ b/tests/test_models/test_engine/test_get_count.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python3
+""" Test .get() and .count() methods
+"""
+from models import storage
+from models.state import State
+
+print("All objects: {}".format(storage.count()))
+print("State objects: {}".format(storage.count(State)))
+
+first_state_id = list(storage.all(State).values())[0].id
+print("First state: {}".format(storage.get(State, first_state_id)))


### PR DESCRIPTION
## Description
This PR implements the `get` and `count` methods in the DBStorage and FileStorage classes. 

- `get(cls, id)`: This method will retrieve the object based on the class and its ID, or None if not found.
- `count(cls=None)`: This method will return the number of objects in storage matching the given class.
If no class is passed, count method will return the number of all objects present in storage.

## Changes
- Added `get` method to DBStorage and FileStorage.
- Added `count` method to DBStorage and FileStorage.
- Updated tests to cover the new methods.